### PR TITLE
Rtps gen pr

### DIFF
--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -75,7 +75,7 @@ int micrortps_client_main(int argc, char *argv[])
     usleep(2000000);
 
     UART_node m_uartNode;
-    if (0 != m_uartNode.init_uart(device, baudrate))
+    if (m_uartNode.init_uart(device, baudrate) < 0)
     {
         printf("ERROR UART INIT, EXITING...\n");
         return -1;

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -45,27 +45,37 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 #define UPDATE_TIME_MS 0
 #define LOOPS 10000
 #define USLEEP_MS 0
+#define BAUDRATE 460800
+#define DEVICE "/dev/ttyACM0"
 
 extern "C" __EXPORT int micrortps_client_main(int argc, char *argv[]);
 
 int micrortps_client_main(int argc, char *argv[])
 {
+    // TODO use proper options with getopt here
+    const char *device = DEVICE;
+    if (argc > 1) device = argv[1];
+
     int update_time = UPDATE_TIME_MS;
-    if (argc > 1) update_time = atoi(argv[1]);
+    if (argc > 2) update_time = atoi(argv[2]);
 
     int poll_time = POLL_TIME_MS;
-    if (argc > 2) poll_time = atoi(argv[2]);
+    if (argc > 3) poll_time = atoi(argv[3]);
 
     int loops = LOOPS;
-    if (argc > 3) loops = atoi(argv[3]);
+    if (argc > 4) loops = atoi(argv[4]);
 
     int usleep_ms = USLEEP_MS;
-    if (argc > 4) usleep_ms = atoi(argv[4]);
+    if (argc > 5) usleep_ms = atoi(argv[5]);
 
-    printf("update: %dms poll: %dms loops: %d usleep_ms: %d\n", update_time, poll_time, loops, usleep_ms);
+    uint32_t baudrate = BAUDRATE;
+    if (argc > 6) baudrate = atoi(argv[6]);
+
+    printf("device: %s update: %dms poll: %dms loops: %d usleep_ms: %d baudrate: %d\n", device, update_time, poll_time, loops, usleep_ms, baudrate);
+    usleep(2000000);
 
     UART_node m_uartNode;
-    if (0 != m_uartNode.init_uart("/dev/ttyACM0"))
+    if (0 != m_uartNode.init_uart(device, baudrate))
     {
         printf("ERROR UART INIT, EXITING...\n");
         return -1;

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -74,8 +74,9 @@ int micrortps_client_main(int argc, char *argv[])
     printf("device: %s update: %dms poll: %dms loops: %d usleep_ms: %d baudrate: %d\n", device, update_time, poll_time, loops, usleep_ms, baudrate);
     usleep(2000000);
 
+    int uart_fd;
     UART_node m_uartNode;
-    if (m_uartNode.init_uart(device, baudrate) < 0)
+    if ((uart_fd = m_uartNode.init_uart(device, baudrate)) < 0)
     {
         printf("ERROR UART INIT, EXITING...\n");
         return -1;
@@ -130,6 +131,11 @@ int micrortps_client_main(int argc, char *argv[])
     uint32_t sent = 0, received = 0;
     uint64_t total_send_lenght = 0;
 
+    // We poll on UART, so we can use protocol splitter driver
+    struct pollfd poll_fd[1] = { };
+    poll_fd[0].fd = uart_fd;
+    poll_fd[0].events = POLLIN;
+
     struct timespec begin;
     clock_gettime(0, &begin);
     int i = 0;
@@ -161,24 +167,30 @@ int micrortps_client_main(int argc, char *argv[])
         }
 @[end if]@
 
-        usleep(usleep_ms);
 @[if recv_topics]@
-        char topic_ID = 255;
-        while (0 < m_uartNode.readFromUART(&topic_ID, data_buffer, BUFFER_SIZE))
+        int r = poll(poll_fd, 1, 100);
+        if (r == 1 && poll_fd[0].revents & POLLIN)
         {
-            switch (topic_ID)
+            char topic_ID = 255;
+            while (0 < m_uartNode.readFromUART(&topic_ID, data_buffer, BUFFER_SIZE))
             {
+                switch (topic_ID)
+                {
 @[for topic in recv_topics]@
-                case @(message_id(topic)):
-                    deserialize_@(topic)(&@(topic)_data, data_buffer, &microCDRReader);
-                    orb_publish(ORB_ID(@(topic)), @(topic)_pub, &@(topic)_data);
-                    //printf("                >>[%d] %llu\n", @(message_id(topic)), @(topic)_data.timestamp);
-                    ++received;
-                break;
+                    case @(message_id(topic)):
+                        deserialize_@(topic)(&@(topic)_data, data_buffer, &microCDRReader);
+                        orb_publish(ORB_ID(@(topic)), @(topic)_pub, &@(topic)_data);
+                        //printf("                >>[%d] %llu\n", @(message_id(topic)), @(topic)_data.timestamp);
+                        ++received;
+                    break;
 @[end for]@
+                }
             }
         }
 @[end if]@
+
+        usleep(usleep_ms);
+
         // loop forever if informed loop number is negative
         if (loops > 0 && ++i >= loops)
             break;

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -72,10 +72,6 @@ int micrortps_client_main(int argc, char *argv[])
     }
 
     char data_buffer[BUFFER_SIZE] = {};
-@[if recv_topics]@
-    char rx_buffer[BUFFER_SIZE] = {};
-    uint32_t rx_buff_pos = 0u;
-@[end if]@
 @[if send_topics]@
 
     /* subscribe to topics */
@@ -158,7 +154,7 @@ int micrortps_client_main(int argc, char *argv[])
         usleep(usleep_ms);
 @[if recv_topics]@
         char topic_ID = 255;
-        while (0 < m_uartNode.readFromUART(&topic_ID, data_buffer, rx_buffer, rx_buff_pos, BUFFER_SIZE))
+        while (0 < m_uartNode.readFromUART(&topic_ID, data_buffer, BUFFER_SIZE))
         {
             switch (topic_ID)
             {

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -133,7 +133,7 @@ int micrortps_client_main(int argc, char *argv[])
     struct timespec begin;
     clock_gettime(0, &begin);
     int i = 0;
-    for (i = 0; i < loops; ++i)
+    while (true)
     {
 @[if send_topics]@
         int poll_ret = px4_poll(fds, @(len(send_topics)), poll_time);
@@ -179,6 +179,9 @@ int micrortps_client_main(int argc, char *argv[])
             }
         }
 @[end if]@
+        // loop forever if informed loop number is negative
+        if (loops > 0 && ++i >= loops)
+            break;
     }
 
     struct timespec end;

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -86,13 +86,12 @@ int micrortps_client_main(int argc, char *argv[])
 @[if send_topics]@
 
     /* subscribe to topics */
-    px4_pollfd_struct_t fds[@(len(send_topics))];
+    int fds[@(len(send_topics))];
 
     // orb_set_interval statblish an update interval period in milliseconds.
 @[for idx, topic in enumerate(send_topics)]@
-    fds[@(idx)].fd = orb_subscribe(ORB_ID(@(topic)));
-    orb_set_interval(fds[@(idx)].fd, update_time);
-    fds[@(idx)].events = POLLIN;
+    fds[@(idx)] = orb_subscribe(ORB_ID(@(topic)));
+    orb_set_interval(fds[@(idx)], update_time);
 @[end for]@
 @[end if]@
 @[if recv_topics]@
@@ -124,7 +123,6 @@ int micrortps_client_main(int argc, char *argv[])
 @[end if]@
 
 @[if send_topics]@
-    int error_counter = 0;
     uint32_t length = 0;
     uint8_t seq = 0;
 @[end if]@
@@ -142,29 +140,22 @@ int micrortps_client_main(int argc, char *argv[])
     while (true)
     {
 @[if send_topics]@
-        int poll_ret = px4_poll(fds, @(len(send_topics)), poll_time);
-
-        if (poll_ret < 0)
-        {
-            ++error_counter;
-        }
-        else
-        {
+        bool updated;
 @[for idx, topic in enumerate(send_topics)]@
-            if (fds[@(idx)].revents & POLLIN)
-            {
-                // obtained data for the file descriptor
-                struct @(topic)_s data;
-                // copy raw data into local buffer
-                orb_copy(ORB_ID(@(topic)), fds[@(idx)].fd, &data);
-                serialize_@(topic)(&data, data_buffer, &length, &microCDRWriter);
-                m_uartNode.writeToUART((char)@(message_id(topic)), data_buffer, length, seq++);
-                //printf("[%d]>> %llu\n", @(message_id(topic)), data.timestamp);
-                ++sent;
-                total_send_lenght += (length + 9);
-            }
-@[end for]@
+        orb_check(fds[@(idx)], &updated);
+        if (updated)
+        {
+            // obtained data for the file descriptor
+            struct @(topic)_s data;
+            // copy raw data into local buffer
+            orb_copy(ORB_ID(@(topic)), fds[@(idx)], &data);
+            serialize_@(topic)(&data, data_buffer, &length, &microCDRWriter);
+            m_uartNode.writeToUART((char)@(message_id(topic)), data_buffer, length, seq++);
+            //printf("[%d]>> %llu\n", @(message_id(topic)), data.timestamp);
+            ++sent;
+            total_send_lenght += (length + 9);
         }
+@[end for]@
 @[end if]@
 
 @[if recv_topics]@

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -22,6 +22,7 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 
 }@
 #include <px4_config.h>
+#include <px4_getopt.h>
 #include <px4_tasks.h>
 #include <px4_posix.h>
 #include <unistd.h>
@@ -41,10 +42,9 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 @[end for]@
 
 #define BUFFER_SIZE 1024
-#define POLL_TIME_MS 0
 #define UPDATE_TIME_MS 0
 #define LOOPS 10000
-#define USLEEP_MS 0
+#define USLEEP 0
 #define BAUDRATE 460800
 #define DEVICE "/dev/ttyACM0"
 
@@ -65,6 +65,62 @@ struct reader_data {
         orb_advert_t @(topic)_pub;
 @[end for]@
 };
+
+struct options {
+    const char *device;
+    int update_time;
+    int loops;
+    int usleep;
+    uint32_t baudrate;
+} _options = {
+    .device = DEVICE,
+    .update_time = UPDATE_TIME_MS,
+    .loops = LOOPS,
+    .usleep = USLEEP,
+    .baudrate = BAUDRATE
+};
+
+static void usage(const char *name)
+{
+    PX4_INFO("usage: %s [options]", name);
+    PX4_INFO("  -d <device>             UART device. Default /dev/ttyACM0");
+    PX4_INFO("  -u <update_time_ms>     Time for uORB subscribed topics update. Default 0");
+    PX4_INFO("  -l <loops>              How many iterations will this program have. -1 for infinite. Default 10000");
+    PX4_INFO("  -s <sleep_time>         Time (microseconds) for which each iteration sleep. Default 0");
+    PX4_INFO("  -b <baudrate>           UART device baudrate. Default 460800");
+}
+
+static int parse_options(int argc, char *argv[])
+{
+    int ch;
+    int myoptind = 1;
+    const char *myoptarg = nullptr;
+
+    while ((ch = px4_getopt(argc, argv, "d:u:l:s:b:", &myoptind, &myoptarg)) != EOF) {
+        switch (ch) {
+        case 'd':
+            _options.device = myoptarg;
+            break;
+        case 'u':
+            _options.update_time = strtoul(myoptarg, nullptr, 10);
+            break;
+        case 'l':
+            _options.loops = strtol(myoptarg, nullptr, 10);
+            break;
+        case 's':
+            _options.usleep = strtoul(myoptarg, nullptr, 10);
+            break;
+        case 'b':
+            _options.baudrate = strtoul(myoptarg, nullptr, 10);
+            break;
+        default:
+            usage(argv[0]);
+            return -1;
+        }
+    }
+
+    return 0;
+}
 
 void *uart_reader_thread(void *data)
 {
@@ -120,31 +176,15 @@ void *uart_reader_thread(void *data)
 
 int micrortps_client_main(int argc, char *argv[])
 {
-    // TODO use proper options with getopt here
-    const char *device = DEVICE;
-    if (argc > 1) device = argv[1];
+    if (parse_options(argc, argv) < 0)
+        return -1;
 
-    int update_time = UPDATE_TIME_MS;
-    if (argc > 2) update_time = atoi(argv[2]);
-
-    int poll_time = POLL_TIME_MS;
-    if (argc > 3) poll_time = atoi(argv[3]);
-
-    int loops = LOOPS;
-    if (argc > 4) loops = atoi(argv[4]);
-
-    int usleep_ms = USLEEP_MS;
-    if (argc > 5) usleep_ms = atoi(argv[5]);
-
-    uint32_t baudrate = BAUDRATE;
-    if (argc > 6) baudrate = atoi(argv[6]);
-
-    printf("device: %s update: %dms poll: %dms loops: %d usleep_ms: %d baudrate: %d\n", device, update_time, poll_time, loops, usleep_ms, baudrate);
+    printf("device: %s update: %dms loops: %d usleep: %d baudrate: %d\n", _options.device, _options.update_time, _options.loops, _options.usleep, _options.baudrate);
     usleep(2000000);
 
     int uart_fd;
     UART_node m_uartNode;
-    if ((uart_fd = m_uartNode.init_uart(device, baudrate)) < 0)
+    if ((uart_fd = m_uartNode.init_uart(_options.device, _options.baudrate)) < 0)
     {
         printf("ERROR UART INIT, EXITING...\n");
         return -1;
@@ -159,7 +199,7 @@ int micrortps_client_main(int argc, char *argv[])
     // orb_set_interval statblish an update interval period in milliseconds.
 @[for idx, topic in enumerate(send_topics)]@
     fds[@(idx)] = orb_subscribe(ORB_ID(@(topic)));
-    orb_set_interval(fds[@(idx)], update_time);
+    orb_set_interval(fds[@(idx)], _options.update_time);
 @[end for]@
 @[end if]@
 
@@ -229,10 +269,10 @@ int micrortps_client_main(int argc, char *argv[])
 @[end for]@
 @[end if]@
 
-        usleep(usleep_ms);
+        usleep(_options.usleep);
 
         // loop forever if informed loop number is negative
-        if (loops > 0 && ++i >= loops)
+        if (_options.loops > 0 && ++i >= _options.loops)
             _should_exit_task = true;
     }
     pthread_join(_reader_thread, nullptr);

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -101,7 +101,10 @@ void *uart_reader_thread(void *data)
 @[for topic in recv_topics]@
                     case @(message_id(topic)):
                         deserialize_@(topic)(&@(topic)_data, data_buffer, &microCDRReader);
-                        orb_publish(ORB_ID(@(topic)), reader_data->@(topic)_pub, &@(topic)_data);
+                        if (!reader_data->@(topic)_pub)
+                            reader_data->@(topic)_pub = orb_advertise(ORB_ID(@(topic)), &@(topic)_data);
+                        else
+                            orb_publish(ORB_ID(@(topic)), reader_data->@(topic)_pub, &@(topic)_data);
                         //printf("                >>[%d] %llu\n", @(message_id(topic)), @(topic)_data.timestamp);
                         ++_received;
                     break;
@@ -163,11 +166,6 @@ int micrortps_client_main(int argc, char *argv[])
 @[if recv_topics]@
     pthread_t _reader_thread{};
 
-    /* advertise topics */
-@[for topic in recv_topics]@
-    struct @(topic)_s @(topic)_data { };
-    orb_advert_t @(topic)_pub = orb_advertise(ORB_ID(@(topic)), &@(topic)_data);
-@[end for]@
 @[end if]@
 @[if send_topics]@
 
@@ -195,7 +193,7 @@ int micrortps_client_main(int argc, char *argv[])
         .uart_fd = uart_fd,
         .uart_node = m_uartNode,
 @[for topic in recv_topics]@
-        .@(topic)_pub = @(topic)_pub,
+        .@(topic)_pub = nullptr,
 @[end for]@
     };
     pthread_create(&_reader_thread, &reader_attr, uart_reader_thread, &reader_data);

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -48,7 +48,72 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 #define BAUDRATE 460800
 #define DEVICE "/dev/ttyACM0"
 
+@[if recv_topics]@
+void *uart_reader_thread(void *data);
+@[end if]@
+
 extern "C" __EXPORT int micrortps_client_main(int argc, char *argv[]);
+
+static bool _should_exit_task = false;
+static uint32_t _received = 0;
+
+@[if recv_topics]@
+struct reader_data {
+    int uart_fd;
+    UART_node &uart_node;
+@[for topic in recv_topics]@
+        orb_advert_t @(topic)_pub;
+@[end for]@
+};
+
+void *uart_reader_thread(void *data)
+{
+    struct reader_data *reader_data = (struct reader_data *)data;
+
+    // We poll on UART, so we can use protocol splitter driver
+    struct pollfd poll_fd[1] = { };
+    poll_fd[0].fd = reader_data->uart_fd;
+    poll_fd[0].events = POLLIN;
+
+    // microBuffer to deserialize
+    char data_buffer[BUFFER_SIZE] = {};
+    struct microBuffer microBufferReader;
+    initDeserializedAlignedBuffer(data_buffer, BUFFER_SIZE, &microBufferReader);
+    // microCDR structs for managing the microBuffer
+    struct microCDR microCDRReader;
+    initMicroCDR(&microCDRReader, &microBufferReader);
+
+    // TODO maybe a method for each topic handler, so we don't need to
+    // declare all these here?
+@[for topic in recv_topics]@
+    struct @(topic)_s @(topic)_data { };
+@[end for]@
+
+    while (!_should_exit_task) {
+        int r = poll(poll_fd, 1, 100);
+        if (r == 1 && poll_fd[0].revents & POLLIN)
+        {
+            char topic_ID = 255;
+            while (0 < reader_data->uart_node.readFromUART(&topic_ID, data_buffer, BUFFER_SIZE))
+            {
+                switch (topic_ID)
+                {
+@[for topic in recv_topics]@
+                    case @(message_id(topic)):
+                        deserialize_@(topic)(&@(topic)_data, data_buffer, &microCDRReader);
+                        orb_publish(ORB_ID(@(topic)), reader_data->@(topic)_pub, &@(topic)_data);
+                        //printf("                >>[%d] %llu\n", @(message_id(topic)), @(topic)_data.timestamp);
+                        ++_received;
+                    break;
+@[end for]@
+                }
+            }
+        }
+    }
+
+    return nullptr;
+}
+@[end if]@
 
 int micrortps_client_main(int argc, char *argv[])
 {
@@ -94,12 +159,13 @@ int micrortps_client_main(int argc, char *argv[])
     orb_set_interval(fds[@(idx)], update_time);
 @[end for]@
 @[end if]@
+
 @[if recv_topics]@
+    pthread_t _reader_thread{};
 
     /* advertise topics */
 @[for topic in recv_topics]@
-    struct @(topic)_s @(topic)_data;
-    memset(&@(topic)_data, 0, sizeof(@(topic)_data));
+    struct @(topic)_s @(topic)_data { };
     orb_advert_t @(topic)_pub = orb_advertise(ORB_ID(@(topic)), &@(topic)_data);
 @[end for]@
 @[end if]@
@@ -114,30 +180,38 @@ int micrortps_client_main(int argc, char *argv[])
 @[end if]@
 @[if recv_topics]@
 
-    // microBuffer to deserialized using the user defined buffer
-    struct microBuffer microBufferReader;
-    initDeserializedAlignedBuffer(data_buffer, BUFFER_SIZE, &microBufferReader);
-    // microCDR structs for managing the microBuffer
-    struct microCDR microCDRReader;
-    initMicroCDR(&microCDRReader, &microBufferReader);
+    /* Set up and start receiver thread */
+    pthread_attr_t reader_attr;
+
+    struct sched_param param;
+    (void)pthread_attr_getschedparam(&reader_attr, &param);
+    param.sched_priority = SCHED_PRIORITY_MAX - 80;
+    (void)pthread_attr_setschedparam(&reader_attr, &param);
+
+    pthread_attr_init(&reader_attr);
+    pthread_attr_setstacksize(&reader_attr, PX4_STACK_ADJUSTED(2100));
+
+    struct reader_data reader_data {
+        .uart_fd = uart_fd,
+        .uart_node = m_uartNode,
+@[for topic in recv_topics]@
+        .@(topic)_pub = @(topic)_pub,
+@[end for]@
+    };
+    pthread_create(&_reader_thread, &reader_attr, uart_reader_thread, &reader_data);
 @[end if]@
 
 @[if send_topics]@
     uint32_t length = 0;
     uint8_t seq = 0;
 @[end if]@
-    uint32_t sent = 0, received = 0;
+    uint32_t sent = 0;
     uint64_t total_send_lenght = 0;
-
-    // We poll on UART, so we can use protocol splitter driver
-    struct pollfd poll_fd[1] = { };
-    poll_fd[0].fd = uart_fd;
-    poll_fd[0].events = POLLIN;
 
     struct timespec begin;
     clock_gettime(0, &begin);
     int i = 0;
-    while (true)
+    while (!_should_exit_task)
     {
 @[if send_topics]@
         bool updated;
@@ -158,40 +232,19 @@ int micrortps_client_main(int argc, char *argv[])
 @[end for]@
 @[end if]@
 
-@[if recv_topics]@
-        int r = poll(poll_fd, 1, 100);
-        if (r == 1 && poll_fd[0].revents & POLLIN)
-        {
-            char topic_ID = 255;
-            while (0 < m_uartNode.readFromUART(&topic_ID, data_buffer, BUFFER_SIZE))
-            {
-                switch (topic_ID)
-                {
-@[for topic in recv_topics]@
-                    case @(message_id(topic)):
-                        deserialize_@(topic)(&@(topic)_data, data_buffer, &microCDRReader);
-                        orb_publish(ORB_ID(@(topic)), @(topic)_pub, &@(topic)_data);
-                        //printf("                >>[%d] %llu\n", @(message_id(topic)), @(topic)_data.timestamp);
-                        ++received;
-                    break;
-@[end for]@
-                }
-            }
-        }
-@[end if]@
-
         usleep(usleep_ms);
 
         // loop forever if informed loop number is negative
         if (loops > 0 && ++i >= loops)
-            break;
+            _should_exit_task = true;
     }
+    pthread_join(_reader_thread, nullptr);
 
     struct timespec end;
     clock_gettime(0, &end);
     double elapsed_secs2 = double(end.tv_sec - begin.tv_sec) + double(end.tv_nsec - begin.tv_nsec)/double(1000000000);
     printf("\nSENT: %d RECEIVED: %d in %d LOOPS\n%llu bytes in %.03f seconds sent %.02fKB/s\n",
-            sent, received, i, total_send_lenght, elapsed_secs2, (double)total_send_lenght/(1000*elapsed_secs2));
+            sent, _received, i, total_send_lenght, elapsed_secs2, (double)total_send_lenght/(1000*elapsed_secs2));
 
     PX4_INFO("exiting");
     fflush(stdout);

--- a/msg/templates/uorb/microRTPS_client.cpp.template
+++ b/msg/templates/uorb/microRTPS_client.cpp.template
@@ -203,7 +203,6 @@ int micrortps_client_main(int argc, char *argv[])
 
 @[if send_topics]@
     uint32_t length = 0;
-    uint8_t seq = 0;
 @[end if]@
     uint32_t sent = 0;
     uint64_t total_send_lenght = 0;
@@ -224,7 +223,7 @@ int micrortps_client_main(int argc, char *argv[])
             // copy raw data into local buffer
             orb_copy(ORB_ID(@(topic)), fds[@(idx)], &data);
             serialize_@(topic)(&data, data_buffer, &length, &microCDRWriter);
-            m_uartNode.writeToUART((char)@(message_id(topic)), data_buffer, length, seq++);
+            m_uartNode.writeToUART((char)@(message_id(topic)), data_buffer, length);
             //printf("[%d]>> %llu\n", @(message_id(topic)), data.timestamp);
             ++sent;
             total_send_lenght += (length + 9);

--- a/msg/templates/urtps/UART_node.cxx
+++ b/msg/templates/urtps/UART_node.cxx
@@ -132,11 +132,9 @@ uint8_t UART_node::close_uart()
     return 0;
 }
 
-int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], char rx_buffer[], uint32_t &rx_buff_pos, uint32_t buff_total_len)
+int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], uint32_t buff_total_len)
 {
-    if (-1 == m_uart_filestream ||
-        nullptr == out_buffer ||
-        nullptr == rx_buffer)
+    if (-1 == m_uart_filestream || nullptr == out_buffer)
         return -1;
 
     // Read up to max_size characters from the port if they are there
@@ -144,7 +142,7 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], char rx_buffe
     //uint32_t &pos_to_write = rx_buff_pos;
     int rx_length = 0;
 
-    int len = read(m_uart_filestream, (void*)(rx_buffer + rx_buff_pos), buff_total_len - rx_buff_pos);
+    int len = read(m_uart_filestream, (void*)(rx_buffer + rx_buff_pos), sizeof(rx_buffer) - rx_buff_pos);
 
     if (len <= 0)
     {

--- a/msg/templates/urtps/UART_node.cxx
+++ b/msg/templates/urtps/UART_node.cxx
@@ -67,7 +67,7 @@ UART_node::~UART_node()
     close_uart();
 }
 
-uint8_t UART_node::init_uart(const char * uart_name)
+uint8_t UART_node::init_uart(const char * uart_name, uint32_t baudrate)
 {
     // Open a serial port
     m_uart_filestream = open(uart_name, O_RDWR | O_NOCTTY | O_NONBLOCK);
@@ -76,6 +76,11 @@ uint8_t UART_node::init_uart(const char * uart_name)
     {
         printf("failed to open port: %s\n", uart_name);
         return 1;
+    }
+
+    // If using shared UART, no need to set it up
+    if (baudrate == 0) {
+        return 0;
     }
 
     // Try to set baud rate
@@ -96,7 +101,7 @@ uint8_t UART_node::init_uart(const char * uart_name)
     if (strcmp(uart_name, "/dev/ttyACM0") != 0 && strcmp(uart_name, "/dev/ttyACM1") != 0)
     {
         // Set baud rate
-        if (cfsetispeed(&uart_config, B115200) < 0 || cfsetospeed(&uart_config, B115200) < 0)
+        if (cfsetispeed(&uart_config, baudrate) < 0 || cfsetospeed(&uart_config, baudrate) < 0)
         {
             printf("ERR SET BAUD %s: %d\n", uart_name, termios_state);
             close(m_uart_filestream);

--- a/msg/templates/urtps/UART_node.cxx
+++ b/msg/templates/urtps/UART_node.cxx
@@ -144,9 +144,9 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], char rx_buffe
     //uint32_t &pos_to_write = rx_buff_pos;
     int rx_length = 0;
 
-    int readed = read(m_uart_filestream, (void*)(rx_buffer + rx_buff_pos), buff_total_len - rx_buff_pos);
+    int len = read(m_uart_filestream, (void*)(rx_buffer + rx_buff_pos), buff_total_len - rx_buff_pos);
 
-    if (readed <= 0)
+    if (len <= 0)
     {
         int errsv = errno;
         //printf("UART Fail %d\n", errsv);
@@ -158,28 +158,28 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], char rx_buffe
         return -1;
     }
 
-    //printf("readed %d\n", readed);
+    //printf("read %d\n", len);
 
     /*printf(">>> |");
-    for (int i = 0; i < rx_buff_pos + readed; ++i)printf(" %hhu", rx_buffer[i]);
+    for (int i = 0; i < rx_buff_pos + len; ++i)printf(" %hhu", rx_buffer[i]);
     printf("\n");*/
 
     // We read some
-    uint32_t last_valid_pos = rx_buff_pos + readed - 1;
+    uint32_t last_valid_pos = rx_buff_pos + len - 1;
     uint32_t msg_start_pos = 0;
     for (msg_start_pos = 0; msg_start_pos <= last_valid_pos - 2; ++msg_start_pos)
     {
         if ('>' == rx_buffer[msg_start_pos] && strncmp(rx_buffer + msg_start_pos, ">>>", 3) == 0)
         {
-            //printf("start founded at %u\n", msg_start_pos);
+            //printf("start found at %u\n", msg_start_pos);
             break;
         }
     }
 
-    // Start not founded
+    // Start not found
     if (msg_start_pos > last_valid_pos - 2)
     {
-        //printf("start not founded, pos %u\n", last_valid_pos);
+        //printf("start not found, pos %u\n", last_valid_pos);
         printf("                                 (↓↓ %u)\n", last_valid_pos - 1);
         rx_buffer[0] = rx_buffer[last_valid_pos - 1];
         rx_buffer[1] = rx_buffer[last_valid_pos];

--- a/msg/templates/urtps/UART_node.cxx
+++ b/msg/templates/urtps/UART_node.cxx
@@ -240,11 +240,12 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], uint32_t buff
 }
 
 
-int16_t UART_node::writeToUART(const char topic_ID, char buffer[], uint32_t length, uint8_t seq)
+int16_t UART_node::writeToUART(const char topic_ID, char buffer[], uint32_t length)
 {
     static struct Header header {
         .marker = {'>','>','>'}
     };
+    static uint8_t seq = 0;
 
     if (m_uart_filestream == -1) return 2;
 
@@ -254,7 +255,7 @@ int16_t UART_node::writeToUART(const char topic_ID, char buffer[], uint32_t leng
 
     int ret = 0;
     header.topic_ID = topic_ID;
-    header.seq = seq;
+    header.seq = seq++;
     header.payload_len = length;
     header.crc_h = (crc >> 8) & 0xff;
     header.crc_l = crc & 0xff;

--- a/msg/templates/urtps/UART_node.cxx
+++ b/msg/templates/urtps/UART_node.cxx
@@ -140,7 +140,6 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], uint32_t buff
     // Read up to max_size characters from the port if they are there
 
     //uint32_t &pos_to_write = rx_buff_pos;
-    int rx_length = 0;
 
     int len = read(m_uart_filestream, (void*)(rx_buffer + rx_buff_pos), sizeof(rx_buffer) - rx_buff_pos);
 
@@ -155,6 +154,7 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], uint32_t buff
         }
         return -1;
     }
+    rx_buff_pos += len;
 
     //printf("read %d\n", len);
 
@@ -163,11 +163,13 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], uint32_t buff
     printf("\n");*/
 
     // We read some
-    uint32_t last_valid_pos = rx_buff_pos + len - 1;
+    if (rx_buff_pos < sizeof(struct Header))
+        return 0; //but not enough
+
     uint32_t msg_start_pos = 0;
-    for (msg_start_pos = 0; msg_start_pos <= last_valid_pos - 2; ++msg_start_pos)
+    for (msg_start_pos = 0; msg_start_pos < rx_buff_pos - 3; ++msg_start_pos)
     {
-        if ('>' == rx_buffer[msg_start_pos] && strncmp(rx_buffer + msg_start_pos, ">>>", 3) == 0)
+        if ('>' == rx_buffer[msg_start_pos] && memcmp(rx_buffer + msg_start_pos, ">>>", 3) == 0)
         {
             //printf("start found at %u\n", msg_start_pos);
             break;
@@ -175,121 +177,104 @@ int16_t UART_node::readFromUART(char* topic_ID, char out_buffer[], uint32_t buff
     }
 
     // Start not found
-    if (msg_start_pos > last_valid_pos - 2)
+    if (msg_start_pos >= rx_buff_pos - 3)
     {
         //printf("start not found, pos %u\n", last_valid_pos);
-        printf("                                 (↓↓ %u)\n", last_valid_pos - 1);
-        rx_buffer[0] = rx_buffer[last_valid_pos - 1];
-        rx_buffer[1] = rx_buffer[last_valid_pos];
-        rx_buff_pos = 2;
+        rx_buff_pos = 0; // All we've read so far is garbage, drop it
         return -1;
     }
 
     /*
-     * [>,>,>,topic_ID,seq,payload_length,payloadStart, ... ,payloadEnd,CRCHigh,CRCLow,<,<,<]
+     * [>,>,>,topic_ID,seq,payload_length,CRCHigh,CRCLow,payloadStart, ... ,payloadEnd]
      */
 
-    // Start detected
-    uint8_t msg_len_pos = msg_start_pos + 5;
-
-    // We don't have space for the rest of message
-    if ((uint32_t(msg_len_pos) > uint32_t(buff_total_len - 1)) ||
-        (uint32_t(msg_len_pos + uint8_t(rx_buffer[msg_len_pos]) + 2) > uint32_t(buff_total_len - 1)))
-    {
-        /*if (msg_len_pos > buff_total_len - 1)
-            printf("don't have space, len_pos %hhu\n", msg_len_pos);
-        else
-        {
-            printf("don't have space, len_pos %hhu, len %hhu, MAX %u, %u > %u\n",
-                    msg_len_pos, rx_buffer[msg_len_pos], buff_total_len-1, uint32_t(msg_len_pos + uint8_t(rx_buffer[msg_len_pos]) + 2), uint32_t(buff_total_len - 1));
-        }*/
-
-        printf("                                 (↓ %u)\n", msg_start_pos);
-        memmove(rx_buffer, rx_buffer + msg_start_pos, last_valid_pos - msg_start_pos + 1);
-        rx_buff_pos = last_valid_pos - msg_start_pos + 1;
+    // Start detected but we should have a complete header, at least
+    if (rx_buff_pos - msg_start_pos < sizeof(struct Header *))
         return 0;
-    }
 
-    uint8_t payload_len = rx_buffer[msg_len_pos];
+    struct Header *header = (struct Header *)&rx_buffer[msg_start_pos];
 
     //printf("payload_len %hhu\n", payload_len);
 
     // We do not have a complete message yet
-    if(msg_len_pos + payload_len + 2 > last_valid_pos)
+    if(msg_start_pos + sizeof(struct Header) + header->payload_len > rx_buff_pos)
     {
-        rx_buff_pos = last_valid_pos + 1;
+        // If there's garbage at the beginning, drop it
+        if (msg_start_pos > 0)
+        {
+            memmove(rx_buffer, rx_buffer + msg_start_pos, rx_buff_pos - msg_start_pos);
+            rx_buff_pos -= msg_start_pos;
+        }
         //printf("do not have a complete message, pos %u\n", rx_buff_pos);
         return 0;
     }
 
     // We have the whole message
-    uint8_t msg_end_pos = msg_len_pos + payload_len + 2;
-    uint32_t crc_pos = msg_len_pos + payload_len + 1;
-    uint16_t read_crc = ((rx_buffer[crc_pos] << 8) & 0xFF00) + (rx_buffer[crc_pos + 1] & 0x00FF);
-    uint16_t calc_crc = crc16((uint8_t*)rx_buffer + msg_len_pos + 1, payload_len);
-    if (read_crc != calc_crc || 0 == read_crc)
-    {
+    int ret;
+    uint16_t read_crc = ((uint16_t)header->crc_h << 8) | header->crc_l;
+    uint16_t calc_crc = crc16((uint8_t*)rx_buffer + msg_start_pos + sizeof(struct Header), header->payload_len);
+    if (read_crc != calc_crc) {
         printf("BAD CRC %u != %u\n", read_crc, calc_crc);
-        rx_buff_pos = 0;
-        if (last_valid_pos - msg_end_pos > 0)
-        {
-            printf("                                 (↓ %u)\n", msg_end_pos + 1);
-            memmove(rx_buffer, rx_buffer + msg_end_pos + 1, last_valid_pos - msg_end_pos);
-            rx_buff_pos = last_valid_pos - msg_end_pos;
-        }
-        return -1;
+        ret = -1;
+    } else {
+        //printf("GOOD CRC %u == %u\n", read_crc, calc_crc);
+        // copy message to outbuffer and set other return values
+        memmove(out_buffer, rx_buffer + msg_start_pos + sizeof(struct Header), header->payload_len);
+        *topic_ID = header->topic_ID;
+        ret = header->payload_len;
     }
 
-    //printf("GOOD CRC %u == %u\n", read_crc, calc_crc);
+    // discard message from rx_buffer
+    rx_buff_pos -= sizeof(struct Header) + header->payload_len;
+    memmove(rx_buffer, rx_buffer + msg_start_pos + sizeof(struct Header) + header->payload_len, rx_buff_pos);
 
-    *topic_ID = rx_buffer[msg_start_pos + 3];
-    memmove(out_buffer, rx_buffer + msg_len_pos + 1, payload_len);
-    rx_length = payload_len;
-    rx_buff_pos = 0;
-    if (last_valid_pos - msg_end_pos > 0)
-    {
-        memmove(rx_buffer, rx_buffer + msg_end_pos + 1, last_valid_pos - msg_end_pos);
-        rx_buff_pos = last_valid_pos - msg_end_pos;
-    }
-    //printf("whole message, pos %u, len %d\n", rx_buff_pos, rx_length);
-    return rx_length;
+    return ret;
 }
 
 
 int16_t UART_node::writeToUART(const char topic_ID, char buffer[], uint32_t length, uint8_t seq)
 {
+    static struct Header header {
+        .marker = {'>','>','>'}
+    };
+
     if (m_uart_filestream == -1) return 2;
 
-    // [>,>,>,topic_ID,seq,payload_length,payload_start, ... ,payload_end,CRCHigh,CRCLow,<,<,<]
+    // [>,>,>,topic_ID,seq,payload_length,CRCHigh,CRCLow,payload_start, ... ,payload_end]
 
     uint16_t crc = crc16((uint8_t*)buffer, length);
 
     int ret = 0;
-    dprintf(m_uart_filestream, ">>>%c%c%c", topic_ID, seq, (char)length);
+    header.topic_ID = topic_ID;
+    header.seq = seq;
+    header.payload_len = length;
+    header.crc_h = (crc >> 8) & 0xff;
+    header.crc_l = crc & 0xff;
+    ret = write(m_uart_filestream, &header, sizeof(header));
+    if (ret != sizeof(header))
+        goto err;
+
     ret = write(m_uart_filestream, buffer, length);
-
-    if (ret != length)
-    {
-        int errsv = errno;
-        if (ret == -1 )
-        {
-            printf("                               => Writing error '%d'\n", errsv);
-        }
-        else
-        {
-            printf("                               => Writed '%d' != length(%u) error '%d'\n", ret, length, errsv);
-        }
-        return ret;
-    }
-
-    dprintf(m_uart_filestream, "%c%c", uint8_t((crc >> 8) & 0x00FF), uint8_t(crc & 0x00FF));
+    if (ret != sizeof(header))
+        goto err;
 
     /*printf(">>>%hhd %c %c|", topic_ID, seq, (char)length);
     for (int i = 0; i < length; ++i)printf(" %hhu", buffer[i]);
     printf("\n");*/
 
-
     return length;
+
+err:
+    int errsv = errno;
+    if (ret == -1 )
+    {
+        printf("                               => Writing error '%d'\n", errsv);
+    }
+    else
+    {
+        printf("                               => Wrote '%d' != length(%u) error '%d'\n", ret, length, errsv);
+    }
+    return ret;
 }
 
 

--- a/msg/templates/urtps/UART_node.h
+++ b/msg/templates/urtps/UART_node.h
@@ -23,10 +23,10 @@ class UART_node
 public:
     UART_node();
     virtual ~UART_node();
-    
+
     uint8_t init_uart(const char * uart_name);
     uint8_t close_uart();
-    int16_t readFromUART(char* topic_ID, char out_buffer[], char rx_buffer[], uint32_t &rx_buff_pos, uint32_t max_size);
+    int16_t readFromUART(char* topic_ID, char out_buffer[], uint32_t max_size);
     int16_t writeToUART(const char topic_ID, char buffer[], uint32_t length, uint8_t seq);
 
 protected:
@@ -36,4 +36,6 @@ protected:
 protected:
 
     int m_uart_filestream;
+    uint32_t rx_buff_pos;
+    char rx_buffer[1024];
 };

--- a/msg/templates/urtps/UART_node.h
+++ b/msg/templates/urtps/UART_node.h
@@ -27,7 +27,7 @@ public:
     int init_uart(const char * uart_name, uint32_t baudrate);
     uint8_t close_uart();
     int16_t readFromUART(char* topic_ID, char out_buffer[], uint32_t max_size);
-    int16_t writeToUART(const char topic_ID, char buffer[], uint32_t length, uint8_t seq);
+    int16_t writeToUART(const char topic_ID, char buffer[], uint32_t length);
 
 protected:
     uint16_t crc16_byte(uint16_t crc, const uint8_t data);

--- a/msg/templates/urtps/UART_node.h
+++ b/msg/templates/urtps/UART_node.h
@@ -24,7 +24,7 @@ public:
     UART_node();
     virtual ~UART_node();
 
-    uint8_t init_uart(const char * uart_name, uint32_t baudrate);
+    int init_uart(const char * uart_name, uint32_t baudrate);
     uint8_t close_uart();
     int16_t readFromUART(char* topic_ID, char out_buffer[], uint32_t max_size);
     int16_t writeToUART(const char topic_ID, char buffer[], uint32_t length, uint8_t seq);

--- a/msg/templates/urtps/UART_node.h
+++ b/msg/templates/urtps/UART_node.h
@@ -35,7 +35,17 @@ protected:
 
 protected:
 
-    int m_uart_filestream;
-    uint32_t rx_buff_pos;
-    char rx_buffer[1024];
+    int m_uart_filestream = -1;
+    uint32_t rx_buff_pos = 0;
+    char rx_buffer[1024] = {};
+
+private:
+    struct __attribute__((packed)) Header {
+        char marker[3];
+        uint8_t topic_ID;
+        uint8_t seq;
+        uint8_t payload_len;
+        uint8_t crc_h;
+        uint8_t crc_l;
+    };
 };

--- a/msg/templates/urtps/UART_node.h
+++ b/msg/templates/urtps/UART_node.h
@@ -24,7 +24,7 @@ public:
     UART_node();
     virtual ~UART_node();
 
-    uint8_t init_uart(const char * uart_name);
+    uint8_t init_uart(const char * uart_name, uint32_t baudrate);
     uint8_t close_uart();
     int16_t readFromUART(char* topic_ID, char out_buffer[], uint32_t max_size);
     int16_t writeToUART(const char topic_ID, char buffer[], uint32_t length, uint8_t seq);

--- a/msg/templates/urtps/microRTPS_agent.cxx.template
+++ b/msg/templates/urtps/microRTPS_agent.cxx.template
@@ -104,9 +104,6 @@ int main(int argc, char** argv)
     int read = 0;
     char topic_ID = 255;
 @[end if]@
-@[if recv_topics]@
-    uint8_t seq = 0;
-@[end if]@
     struct timespec begin;
     bool start = true, receiving = false;
     do
@@ -152,7 +149,7 @@ int main(int argc, char** argv)
             msg.serialize(scdr);
             size_t len = scdr.getSerializedDataLength();
             //printf("[%d]>> %lu\n", @(id), msg.timestamp());
-            m_uartNode.writeToUART((char) @(message_id(topic)), scdr.getBufferPointer(), len, seq++);
+            m_uartNode.writeToUART((char) @(message_id(topic)), scdr.getBufferPointer(), len);
             ++sent;
         }
 @[end for]@

--- a/msg/templates/urtps/microRTPS_agent.cxx.template
+++ b/msg/templates/urtps/microRTPS_agent.cxx.template
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
     uint32_t baud = 460800;
     if (argc > 1) uart = std::string(argv[1]);
     if (argc > 2) baud = atoi(argv[1]);
-    if (0 != m_uartNode.init_uart(uart.c_str(), baud))
+    if (m_uartNode.init_uart(uart.c_str(), baud) < 0)
     {
         printf("EXITING...\n");
         return -1;

--- a/msg/templates/urtps/microRTPS_agent.cxx.template
+++ b/msg/templates/urtps/microRTPS_agent.cxx.template
@@ -79,10 +79,6 @@ int main(int argc, char** argv)
     if (argc > 2) usleep_ms = atoi(argv[2]);
 
     char data_buffer[BUFFER_SIZE] = {};
-@[if send_topics]@
-    char rx_buffer[BUFFER_SIZE] = {};
-    uint32_t rx_buff_pos = 0u;
-@[end if]@
 @[if recv_topics]@
 
     // Create subscribers
@@ -119,7 +115,7 @@ int main(int argc, char** argv)
             clock_gettime(0, &begin);
         }
         // Publish messages received from UART
-        while (0 < (read = m_uartNode.readFromUART(&topic_ID, data_buffer, rx_buffer, rx_buff_pos, BUFFER_SIZE)))
+        while (0 < (read = m_uartNode.readFromUART(&topic_ID, data_buffer, BUFFER_SIZE)))
         {
             switch (topic_ID)
             {

--- a/msg/templates/urtps/microRTPS_agent.cxx.template
+++ b/msg/templates/urtps/microRTPS_agent.cxx.template
@@ -68,8 +68,10 @@ int main(int argc, char** argv)
 {
     UART_node m_uartNode;
     std::string uart = "/dev/ttyACM0";
+    uint32_t baud = 460800;
     if (argc > 1) uart = std::string(argv[1]);
-    if (0 != m_uartNode.init_uart(uart.c_str()))
+    if (argc > 2) baud = atoi(argv[1]);
+    if (0 != m_uartNode.init_uart(uart.c_str(), baud))
     {
         printf("EXITING...\n");
         return -1;

--- a/src/drivers/protocol_splitter/CMakeLists.txt
+++ b/src/drivers/protocol_splitter/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE drivers__protocol_splitter
+	MAIN protocol_splitter
+	STACK_MAIN 1200
+	SRCS
+		protocol_splitter.cpp
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -1,0 +1,374 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file protocol_splitter.cpp
+ * NuttX Driver to split mavlink 2 and another protocol on a serial port.
+ * Makes sure the two protocols can be read & written simultanously by 2 processes.
+ * It will create two devices:
+ * /dev/protocol
+ * /dev/mavlink
+ */
+
+#include <drivers/device/device.h>
+#include <px4_sem.hpp>
+#include <px4_log.h>
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <cstdint>
+
+
+class ProtocolDev;
+class Mavlink2Dev;
+
+extern "C" __EXPORT int protocol_splitter_main(int argc, char *argv[]);
+
+struct StaticData {
+	ProtocolDev *protocol;
+	Mavlink2Dev *mavlink2;
+	sem_t lock;
+	char device_name[16];
+};
+
+namespace
+{
+static StaticData *objects = nullptr;
+}
+
+
+
+class DevCommon : public device::CDev
+{
+public:
+	DevCommon(const char *device_name, const char *device_path);
+	virtual ~DevCommon();
+
+	virtual int	ioctl(struct file *filp, int cmd, unsigned long arg);
+
+	virtual int	open(file *filp);
+	virtual int	close(file *filp);
+
+protected:
+
+	virtual pollevent_t poll_state(struct file *filp);
+
+
+	void lock()
+	{
+		while (sem_wait(&objects->lock) != 0) {
+			/* The only case that an error should occur here is if
+			 * the wait was awakened by a signal.
+			 */
+			ASSERT(get_errno() == EINTR);
+		}
+	}
+
+	void unlock()
+	{
+		sem_post(&objects->lock);
+	}
+
+	int _fd = -1;
+
+	uint16_t _packet_len;
+	enum class ParserState : uint8_t {
+		Idle = 0,
+		GotLength
+	};
+	ParserState _parser_state = ParserState::Idle;
+
+	bool _had_data = false; ///< whether poll() returned available data
+
+private:
+};
+
+DevCommon::DevCommon(const char *device_name, const char *device_path)
+	: CDev(device_name, device_path)
+{
+}
+
+DevCommon::~DevCommon()
+{
+	if (_fd >= 0) {
+		::close(_fd);
+	}
+}
+
+int DevCommon::ioctl(struct file *filp, int cmd, unsigned long arg)
+{
+	//pretend we have enough space left to write, so mavlink will not drop data and throw off
+	//our parsing state
+	if (cmd == FIONSPACE) {
+		*(int *)arg = 1024;
+		return 0;
+	}
+
+	return ::ioctl(_fd, cmd, arg);
+}
+
+int DevCommon::open(file *filp)
+{
+	_fd = ::open(objects->device_name, O_RDWR | O_NOCTTY);
+	CDev::open(filp);
+	return _fd >= 0 ? 0 : -1;
+}
+
+int DevCommon::close(file *filp)
+{
+	//int ret = ::close(_fd); // FIXME: calling this results in a dead-lock, because DevCommon::close()
+	// is called from within another close(), and NuttX seems to hold a semaphore at this point
+	_fd = -1;
+	CDev::close(filp);
+	return 0;
+}
+
+pollevent_t DevCommon::poll_state(struct file *filp)
+{
+	pollfd fds[1];
+	fds[0].fd = _fd;
+	fds[0].events = POLLIN;
+
+	/* Here we should just check the poll state (which is called before an actual poll waiting).
+	 * Instead we poll on the fd with some timeout, and then pretend that there is data.
+	 * This will let the calling poll return immediately (there's still no busy loop since
+	 * we do actually poll here).
+	 * We do this because there is no simple way with the given interface to poll on
+	 * the _fd in here or by overriding some other method.
+	 */
+
+	int ret = ::poll(fds, sizeof(fds) / sizeof(fds[0]), 100);
+	_had_data = ret > 0 && (fds[0].revents & POLLIN);
+
+	return POLLIN;
+}
+
+
+class ProtocolDev : public DevCommon
+{
+public:
+	ProtocolDev();
+	virtual ~ProtocolDev() {}
+
+	virtual ssize_t	read(struct file *filp, char *buffer, size_t buflen);
+	virtual ssize_t	write(struct file *filp, const char *buffer, size_t buflen);
+
+};
+
+ProtocolDev::ProtocolDev()
+	: DevCommon("Protocol", "/dev/protocol")
+{
+}
+
+ssize_t ProtocolDev::read(struct file *filp, char *buffer, size_t buflen)
+{
+	PX4_ERR("read from protocol unsupported");
+	return 0;
+}
+
+ssize_t ProtocolDev::write(struct file *filp, const char *buffer, size_t buflen)
+{
+	// TODO: something similar as Mavlink2Dev::write()
+
+	return 0;
+}
+
+
+class Mavlink2Dev : public DevCommon
+{
+public:
+	Mavlink2Dev();
+	virtual ~Mavlink2Dev() {}
+
+	virtual ssize_t	read(struct file *filp, char *buffer, size_t buflen);
+	virtual ssize_t	write(struct file *filp, const char *buffer, size_t buflen);
+
+};
+
+Mavlink2Dev::Mavlink2Dev()
+	: DevCommon("Mavlink2", "/dev/mavlink")
+{
+}
+
+ssize_t Mavlink2Dev::read(struct file *filp, char *buffer, size_t buflen)
+{
+	if (!_had_data) {
+		return 0;
+	}
+
+	//no need for locking here
+	return ::read(_fd, buffer, buflen);
+}
+
+ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
+{
+	/*
+	 * we need to look into the data to make sure the output is locked for the duration
+	 * of a whole packet.
+	 * assumptions:
+	 * - packet header is written all at once (or at least it contains the payload length)
+	 * - a single write call does not contain multiple (or parts of multiple) packets
+	 */
+	ssize_t ret = 0;
+
+	switch (_parser_state) {
+	case ParserState::Idle:
+		ASSERT(buflen >= 3);
+
+		if ((unsigned char)buffer[0] == 253) {
+			uint8_t payload_len = buffer[1];
+			uint8_t incompat_flags = buffer[2];
+			_packet_len = payload_len + 12;
+
+			if (incompat_flags & 0x1) { //signing
+				_packet_len += 13;
+			}
+
+			_parser_state = ParserState::GotLength;
+			lock();
+
+		} else if ((unsigned char)buffer[0] == 254) { // mavlink 1
+			uint8_t payload_len = buffer[1];
+			_packet_len = payload_len + 8;
+
+			_parser_state = ParserState::GotLength;
+			lock();
+
+		} else {
+			PX4_ERR("parser error");
+			return 0;
+		}
+
+	//no break
+	case ParserState::GotLength: {
+			_packet_len -= buflen;
+			int buf_free;
+			::ioctl(_fd, FIONSPACE, (unsigned long)&buf_free);
+
+			if (buf_free < buflen) {
+				//let write fail, to let mavlink know the buffer would overflow
+				//(this is because in the ioctl we pretend there is always enough space)
+				ret = -1;
+
+			} else {
+				ret = ::write(_fd, buffer, buflen);
+			}
+
+			if (_packet_len == 0) {
+				unlock();
+				_parser_state = ParserState::Idle;
+			}
+		}
+
+		break;
+	}
+
+	return ret;
+}
+
+
+int protocol_splitter_main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		goto out;
+	}
+
+	/*
+	 * Start/load the driver.
+	 */
+	if (!strcmp(argv[1], "start")) {
+		if (objects) {
+			PX4_ERR("already running");
+			return 1;
+		}
+
+		if (argc != 3) {
+			goto out;
+		}
+
+		objects = new StaticData();
+
+		if (!objects) {
+			PX4_ERR("alloc failed");
+			return -1;
+		}
+
+		strncpy(objects->device_name, argv[2], sizeof(objects->device_name));
+		sem_init(&objects->lock, 1, 1);
+		objects->mavlink2 = new Mavlink2Dev();
+		objects->protocol = new ProtocolDev();
+
+		if (!objects->mavlink2 || !objects->protocol) {
+			delete objects->protocol;
+			delete objects->mavlink2;
+			sem_destroy(&objects->lock);
+			delete objects;
+			objects = nullptr;
+			PX4_ERR("alloc failed");
+			return -1;
+
+		} else {
+			objects->mavlink2->init();
+			objects->protocol->init();
+		}
+	}
+
+	if (!strcmp(argv[1], "stop")) {
+		if (objects) {
+			delete objects->protocol;
+			delete objects->mavlink2;
+			sem_destroy(&objects->lock);
+			delete objects;
+			objects = nullptr;
+		}
+	}
+
+	/*
+	 * Print driver status.
+	 */
+	if (!strcmp(argv[1], "status")) {
+		if (objects) {
+			PX4_INFO("running");
+
+		} else {
+			PX4_INFO("not running");
+		}
+	}
+
+	return 0;
+
+out:
+	PX4_ERR("unrecognized command, try 'start <device>', 'stop', 'status'");
+	return 1;
+}
+

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -47,15 +47,19 @@
 #include <unistd.h>
 #include <cstdint>
 
-
 class Mavlink2Dev;
+class RtpsDev;
+class ReadBuffer;
 
 extern "C" __EXPORT int protocol_splitter_main(int argc, char *argv[]);
 
 struct StaticData {
 	Mavlink2Dev *mavlink2;
-	sem_t lock;
+	RtpsDev *rtps;
+	sem_t r_lock;
+	sem_t w_lock;
 	char device_name[16];
+	ReadBuffer *read_buffer;
 };
 
 namespace
@@ -63,7 +67,50 @@ namespace
 static StaticData *objects = nullptr;
 }
 
+class ReadBuffer
+{
+public:
+	int read(int fd);
+	void move(void *dest, size_t pos, size_t n);
 
+	uint8_t buffer[512] = {};
+	size_t buf_size = 0;
+
+	static const size_t BUFFER_THRESHOLD = sizeof(buffer) * 0.8;
+};
+
+int ReadBuffer::read(int fd)
+{
+	/* Discard whole buffer if it's filled beyond a threshold,
+	 * This should prevent buffer being filled by garbage that
+	 * no reader (MAVLink or RTPS) can understand.
+	 *
+	 * TODO: a better approach would be checking if both reader
+	 * start understanding messages beyond a certain buffer size,
+	 * meaning that everything before is garbage.
+	 */
+	if (buf_size > BUFFER_THRESHOLD) {
+		buf_size = 0;
+	}
+
+	int r = ::read(fd, buffer + buf_size, sizeof(buffer) - buf_size);
+	if (r < 0)
+		return r;
+
+	buf_size += r;
+
+	return r;
+}
+
+void ReadBuffer::move(void *dest, size_t pos, size_t n)
+{
+	ASSERT(pos < buf_size);
+	ASSERT(pos + n <= buf_size);
+
+	memmove(dest, buffer + pos, n); // send desired data
+	memmove(buffer + pos, buffer + (pos + n), sizeof(buffer) - pos - n);
+	buf_size -= n;
+}
 
 class DevCommon : public device::CDev
 {
@@ -76,14 +123,17 @@ public:
 	virtual int	open(file *filp);
 	virtual int	close(file *filp);
 
+	enum Operation {Read, Write};
+
 protected:
 
 	virtual pollevent_t poll_state(struct file *filp);
 
 
-	void lock()
+	void lock(enum Operation op)
 	{
-		while (sem_wait(&objects->lock) != 0) {
+		sem_t *lock = op == Read ? &objects->r_lock : &objects->w_lock;
+		while (sem_wait(lock) != 0) {
 			/* The only case that an error should occur here is if
 			 * the wait was awakened by a signal.
 			 */
@@ -91,9 +141,10 @@ protected:
 		}
 	}
 
-	void unlock()
+	void unlock(enum Operation op)
 	{
-		sem_post(&objects->lock);
+		sem_t *lock = op == Read ? &objects->r_lock : &objects->w_lock;
+		sem_post(lock);
 	}
 
 	int _fd = -1;
@@ -173,27 +224,107 @@ pollevent_t DevCommon::poll_state(struct file *filp)
 class Mavlink2Dev : public DevCommon
 {
 public:
-	Mavlink2Dev();
+	Mavlink2Dev(ReadBuffer *_read_buffer);
 	virtual ~Mavlink2Dev() {}
 
 	virtual ssize_t	read(struct file *filp, char *buffer, size_t buflen);
 	virtual ssize_t	write(struct file *filp, const char *buffer, size_t buflen);
 
+protected:
+	ReadBuffer *_read_buffer;
+	size_t _remaining_partial = 0;
+	size_t _partial_start = 0;
+	uint8_t _partial_buffer[512] = {};
 };
 
-Mavlink2Dev::Mavlink2Dev()
+Mavlink2Dev::Mavlink2Dev(ReadBuffer *read_buffer)
 	: DevCommon("Mavlink2", "/dev/mavlink")
+	, _read_buffer{read_buffer}
 {
 }
 
 ssize_t Mavlink2Dev::read(struct file *filp, char *buffer, size_t buflen)
 {
+	int i, ret;
+	uint16_t packet_len = 0;
+
+	/* last reading was partial (i.e., buffer didn't fit whole message),
+	 * so now we'll just send remaining bytes */
+	if (_remaining_partial > 0) {
+		size_t len = _remaining_partial;
+		if (buflen < len) {
+			len = buflen;
+		}
+		memmove(buffer, _partial_buffer + _partial_start, len);
+		_partial_start += len;
+		_remaining_partial -= len;
+
+		if (_remaining_partial == 0) {
+			_partial_start = 0;
+		}
+		return len;
+	}
+
 	if (!_had_data) {
 		return 0;
 	}
 
-	//no need for locking here
-	return ::read(_fd, buffer, buflen);
+	lock(Read);
+	ret = _read_buffer->read(_fd);
+
+	if (ret < 0)
+		goto end;
+
+	ret = 0;
+
+	if (_read_buffer->buf_size < 3)
+		goto end;
+
+	// Search for a mavlink packet on buffer to send it
+	i = 0;
+	while (i < (_read_buffer->buf_size - 3)
+			&& _read_buffer->buffer[i] != 253
+			&& _read_buffer->buffer[i] != 254)
+		i++;
+
+	// We need at least the first three bytes to get packet len
+	if (i >= _read_buffer->buf_size - 3) {
+		goto end;
+	}
+
+	if (_read_buffer->buffer[i] == 253) {
+		uint8_t payload_len = _read_buffer->buffer[i + 1];
+		uint8_t incompat_flags = _read_buffer->buffer[i + 2];
+		packet_len = payload_len + 12;
+
+		if (incompat_flags & 0x1) { //signing
+			packet_len += 13;
+		}
+	} else {
+		packet_len = _read_buffer->buffer[i + 1] + 8;
+	}
+
+	// packet is bigger than what we've read, better luck next time
+	if (i + packet_len > _read_buffer->buf_size) {
+		goto end;
+	}
+
+	/* if buffer doesn't fit message, send what's possible and copy remaining
+	 * data into a temporary buffer on this class */
+	if (packet_len > buflen) {
+		_read_buffer->move(buffer, i, buflen);
+		_read_buffer->move(_partial_buffer, i + buflen, packet_len - buflen);
+		_remaining_partial = packet_len - buflen;
+		ret = buflen;
+		goto end;
+	}
+
+	_read_buffer->move(buffer, i, packet_len);
+	ret = packet_len;
+
+end:
+	unlock(Read);
+	return ret;
 }
 
 ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
@@ -221,14 +352,14 @@ ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
 			}
 
 			_parser_state = ParserState::GotLength;
-			lock();
+			lock(Write);
 
 		} else if ((unsigned char)buffer[0] == 254) { // mavlink 1
 			uint8_t payload_len = buffer[1];
 			_packet_len = payload_len + 8;
 
 			_parser_state = ParserState::GotLength;
-			lock();
+			lock(Write);
 
 		} else {
 			PX4_ERR("parser error");
@@ -251,7 +382,7 @@ ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
 			}
 
 			if (_packet_len == 0) {
-				unlock();
+				unlock(Write);
 				_parser_state = ParserState::Idle;
 			}
 		}
@@ -262,6 +393,130 @@ ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
 	return ret;
 }
 
+class RtpsDev : public DevCommon
+{
+public:
+	RtpsDev(ReadBuffer *_read_buffer);
+	virtual ~RtpsDev() {}
+
+	virtual ssize_t	read(struct file *filp, char *buffer, size_t buflen);
+	virtual ssize_t	write(struct file *filp, const char *buffer, size_t buflen);
+
+protected:
+	ReadBuffer *_read_buffer;
+
+	static const uint8_t HEADER_SIZE = 8;
+};
+
+RtpsDev::RtpsDev(ReadBuffer *read_buffer)
+	: DevCommon("Rtps", "/dev/rtps")
+	, _read_buffer{read_buffer}
+{
+}
+
+ssize_t RtpsDev::read(struct file *filp, char *buffer, size_t buflen)
+{
+	int i, ret;
+	uint16_t packet_len;
+
+	if (!_had_data) {
+		return 0;
+	}
+
+	lock(Read);
+	ret = _read_buffer->read(_fd);
+
+	if (ret < 0) {
+		goto end;
+	}
+	ret = 0;
+
+	if (_read_buffer->buf_size < HEADER_SIZE)
+		goto end; // starting ">>>" + topic + seq + len + crchigh + crclow
+
+	// Search for a rtps packet on buffer to send it
+	// Search for a mavlink packet on buffer to send it
+	i = 0;
+	while (i < (_read_buffer->buf_size - HEADER_SIZE) && (memcmp(_read_buffer->buffer + i, ">>>", 3) != 0))
+		i++;
+
+	// We need at least the first six bytes to get packet len
+	if (i >= _read_buffer->buf_size - HEADER_SIZE) {
+		goto end;
+	}
+
+	packet_len = _read_buffer->buffer[i + 5] + HEADER_SIZE;
+
+	// packet is bigger than what we've read, better luck next time
+	if (i + packet_len > _read_buffer->buf_size) {
+		goto end;
+	}
+
+	// buffer should be big enough to hold a rtps packet
+	if (packet_len > buflen) {
+		ret = -EMSGSIZE;
+		goto end;
+	}
+
+	_read_buffer->move(buffer, i, packet_len);
+	ret = packet_len;
+
+end:
+	unlock(Read);
+	return ret;
+}
+
+ssize_t RtpsDev::write(struct file *filp, const char *buffer, size_t buflen)
+{
+	/*
+	 * we need to look into the data to make sure the output is locked for the duration
+	 * of a whole packet.
+	 * assumptions:
+	 * - packet header is written all at once (or at least it contains the payload length)
+	 * - a single write call does not contain multiple (or parts of multiple) packets
+	 */
+	ssize_t ret = 0;
+
+	switch (_parser_state) {
+	case ParserState::Idle:
+		ASSERT(buflen >= HEADER_SIZE);
+		if (memcmp(buffer, ">>>", 3) != 0) {
+			PX4_ERR("parser error");
+			return 0;
+		}
+
+		_packet_len = buffer[5] + HEADER_SIZE;
+		_parser_state = ParserState::GotLength;
+		lock(Write);
+
+
+	//no break
+	case ParserState::GotLength: {
+			_packet_len -= buflen;
+			int buf_free;
+			::ioctl(_fd, FIONSPACE, (unsigned long)&buf_free);
+
+			// TODO should I care about this for rtps?
+			if (buf_free < buflen) {
+				//let write fail, to let rtps know the buffer would overflow
+				//(this is because in the ioctl we pretend there is always enough space)
+				ret = -1;
+
+			} else {
+				ret = ::write(_fd, buffer, buflen);
+			}
+
+			if (_packet_len == 0) {
+				unlock(Write);
+				_parser_state = ParserState::Idle;
+			}
+		}
+
+		break;
+	}
+
+	return ret;
+}
 
 int protocol_splitter_main(int argc, char *argv[])
 {
@@ -290,12 +545,18 @@ int protocol_splitter_main(int argc, char *argv[])
 		}
 
 		strncpy(objects->device_name, argv[2], sizeof(objects->device_name));
-		sem_init(&objects->lock, 1, 1);
-		objects->mavlink2 = new Mavlink2Dev();
+		sem_init(&objects->r_lock, 1, 1);
+		sem_init(&objects->w_lock, 1, 1);
+		objects->read_buffer = new ReadBuffer();
+		objects->mavlink2 = new Mavlink2Dev(objects->read_buffer);
+		objects->rtps = new RtpsDev(objects->read_buffer);
 
-		if (!objects->mavlink2) {
+		if (!objects->mavlink2 || !objects->rtps) {
 			delete objects->mavlink2;
-			sem_destroy(&objects->lock);
+			delete objects->rtps;
+			delete objects->read_buffer;
+			sem_destroy(&objects->r_lock);
+			sem_destroy(&objects->w_lock);
 			delete objects;
 			objects = nullptr;
 			PX4_ERR("alloc failed");
@@ -303,13 +564,17 @@ int protocol_splitter_main(int argc, char *argv[])
 
 		} else {
 			objects->mavlink2->init();
+			objects->rtps->init();
 		}
 	}
 
 	if (!strcmp(argv[1], "stop")) {
 		if (objects) {
 			delete objects->mavlink2;
-			sem_destroy(&objects->lock);
+			delete objects->rtps;
+			delete objects->read_buffer;
+			sem_destroy(&objects->r_lock);
+			sem_destroy(&objects->w_lock);
 			delete objects;
 			objects = nullptr;
 		}

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -33,8 +33,8 @@
 px4_add_module(
 	MODULE modules__mavlink
 	MAIN mavlink
-	STACK_MAIN 1200
-	STACK_MAX 1500
+	STACK_MAIN 2000
+	STACK_MAX 2500
 	COMPILE_FLAGS
 	SRCS
 		mavlink.c


### PR DESCRIPTION
Hi,

This PR comprises some changes that I believe to be important for generated code. Basically:
  - Define a uniform header so send CDR serialised messages over UART. 
  - Make `rx_buffer` internal to `UART_node`
  - Use a dedicated thread to read from UART.
  - Stop polling on uORB topics - since we sleep on this loop, so it should be cheaper checking all topics status. The same is done on mavlink module
  - Poll on UART to read from it. This allows usage of protocol splitter driver.

This PR also contains 3 more commits related to protocol splitter driver. I thought of sending them on a separated PR to PX4/Firmware, but it didn't make much sense to me, since there's nothing related to RTPS there yet. Sending here so it can be carried together when RTPS becomes upstream.

Changes are mainly on 'PX4/rtps_client' side. Changes to 'rtps_agent' are only to keep them compatible. I have some work to split mavlink/rtps on UART on companion computer, but I don't think it's worth here, since this scenario looks Intel Aero specific.

Please review: I tried to keep all changes small, and I'm not sure of all of them. For instance, 
I wonder if 'UART_node: make init_uart return UART file descriptor' could be changed to simply expose its internal file descriptor. Last one, 'rtps client: Use getopt to parse command line args' can be superfluous. And even though I've tested them here, maybe some changes break on other scenarios, so please, test too =D

Finally, my branch https://github.com/edersondisouza/Firmware/commits/rtps-gen has some extra commit with changes to allow a test program to be run, as well as the `rtps_router` application (for some messages only). 